### PR TITLE
Fix format check script

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "check:types": "tsc --noEmit",
     "check:biome": "biome check .",
     "format": "biome format --write .",
-    "format:check": "biome format --write --check .",
+    "format:check": "biome format .",
     "lint": "biome lint .",
     "lint:fix": "biome lint --fix .",
     "test": "vitest",


### PR DESCRIPTION
## Summary
- correct `format:check` script to work with Biome

## Testing
- `pnpm run format:check`
- `pnpm run check`
- `pnpm run lint`
- `pnpm exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_684ecc63e914832a97bbc5ab8ff67384