### PR TITLE
Fix format check script

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "check:types": "tsc --noEmit",
     "check:biome": "biome check .",
     "format": "biome format --write .",
-    "format:check": "biome format --write --check .",
+    "format:check": "biome format .",
     "lint": "biome lint .",
     "lint:fix": "biome lint --fix .",
     "test": "vitest",

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,4 +1,4 @@
-import { getCollection } from "astro:content";
+import { type CollectionEntry, getCollection } from "astro:content";
 import { SITE } from "@/site.config";
 import rss from "@astrojs/rss";
 
@@ -8,7 +8,7 @@ export async function GET(context: { site: string }) {
     title: SITE.title,
     description: SITE.description,
     site: context.site,
-    items: posts.map((post) => ({
+    items: posts.map((post: CollectionEntry<"blog">) => ({
       ...post.data,
       link: `/blog/${post.slug}/`,
     })),


### PR DESCRIPTION
## Summary
- correct `format:check` script to work with Biome
- annotate `CollectionEntry` type for RSS feed posts

## Testing
- `pnpm run check`
- `pnpm run lint`
- `pnpm exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_684ecc63e914832a97bbc5ab8ff67384